### PR TITLE
Update material-bootstrap-wizard.js

### DIFF
--- a/assets/js/material-bootstrap-wizard.js
+++ b/assets/js/material-bootstrap-wizard.js
@@ -76,7 +76,10 @@ $(document).ready(function(){
             $('.moving-tab').css('transition','transform 0s');
        },
 
-        onTabClick : function(tab, navigation, index){
+        onTabClick : function(tab, navigation, index, nextIndex){
+	 if (nextIndex <= index) {
+             return;
+           }
             var $valid = $('.wizard-card form').valid();
 
             if(!$valid){


### PR DESCRIPTION
Bug fixed: when moving to the previous tab validaton shouldn't work. Because it's not "next" action.